### PR TITLE
styling changes and rest of the server translations

### DIFF
--- a/locale/ja/server.json
+++ b/locale/ja/server.json
@@ -48,5 +48,15 @@
   "email.change_status.duplicate": "<strong>{title} ({postLink})</strong>は<strong>重複</strong>として<strong>{duplicate}</strong>に閉じられました。",
   "email.change_status.others": "<strong>{title} ({postLink})</strong>のステータスが<strong>{status}</strong>に変更されました。",
   "email.delete_post.text": "<strong>{title}</strong>が<strong>削除</strong>されました。",
-  "email.new_comment.text": "<strong>{userName}</strong>が<strong>{title} ({postLink})</strong>に新しいコメントを投稿しました。"
+  "email.new_comment.text": "<strong>{userName}</strong>が<strong>{title} ({postLink})</strong>に新しいコメントを投稿しました。",
+  "email.new_post.text": "<strong>{userName}</strong> は新しい投稿 <strong>{title} ({postLink})</strong> を作成しました。",
+  "email.signin_email.subject": "{siteName} にサインイン",
+  "email.signin_email.text": "サインインリンクを送信するように頼まれましたので、ここにあります。",
+  "email.signin_email.confirmation": "以下のリンクをクリックして <strong>{siteName}</strong> にサインインします。",
+  "email.signup_email.subject": "あなたの新しい Fider サイト",
+  "email.signup_email.text": "あなたはあなたの Fider サイトをアクティブにするための 1 手順を残しています。",
+  "email.signup_email.confirmation": "以下のリンクを使用して、あなたの電子メールアドレスを確認してアクティベーションプロセスを完了することができます。",
+  "email.footer.subscription_notice": "この投稿に購読しているため、このメールを受信しています。 {view}、{unsubscribe}、または{change}することができます。",
+  "email.footer.subscription_notice2": "この投稿に購読しているため、このメールを受信しています。 {change}することができます。",
+  "email.footer.subscription_notice3": "この投稿に購読しているため、このメールを受信しています。 {view} または{change}することができます。"
 }

--- a/public/components/LocaleChanger.tsx
+++ b/public/components/LocaleChanger.tsx
@@ -1,7 +1,7 @@
-import { useFider } from "@fider/hooks"
-import { Select } from "@fider/components"
-import { activateI18N } from "@fider/services"
 import React, { useState } from "react"
+
+import { useFider } from "@fider/hooks"
+import { activateI18N } from "@fider/services"
 
 import locales from "@locale/locales"
 
@@ -15,19 +15,32 @@ const LocaleChanger = () => {
   }
 
   return (
-    <Select
-      field="locale"
+    <select
+      className="c-select mr-2"
       defaultValue={locale}
-      options={Object.entries(locales).map(([k, v]) => ({
-        value: k,
-        label: v.text,
-      }))}
-      onChange={(o) => {
-        setLocale(o?.value || locale)
-        activateI18N(o?.value || locale)
-        setLocalStorage(o?.value || locale)
+      style={{
+        width: "auto",
+        marginLeft: "auto",
       }}
-    ></Select>
+      onChange={(o) => {
+        setLocale(o.target.value || locale)
+        activateI18N(o.target.value || locale)
+        setLocalStorage(o.target.value || locale)
+      }}
+    >
+      {Object.entries(locales)
+        .map(([k, v]) => ({
+          value: k,
+          label: v.text,
+        }))
+        .map(({ value, label }) => {
+          return (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          )
+        })}
+    </select>
   )
 }
 


### PR DESCRIPTION
server translations are not in effect because -> 
it uses the language that the admin sets the fider instance to, and so to have each user have localized server translations, all the endpoints would need to be passed in the locale (or i understand the fider tenant more, but that's a bit too much work for now). 